### PR TITLE
Integration with Hypergraph Analysis Toolbox (HAT)

### DIFF
--- a/requirements/tutorials.txt
+++ b/requirements/tutorials.txt
@@ -1,3 +1,4 @@
+HypergraphAnalysisToolbox
 hypergraphx
 hypernetx
 networkx

--- a/tutorials/HAT.ipynb
+++ b/tutorials/HAT.ipynb
@@ -19,40 +19,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Install HAT"
+    "## Load HIF File"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Requirement already satisfied: HypergraphAnalysisToolbox in c:\\users\\jpic\\appdata\\local\\programs\\python\\python311\\lib\\site-packages (1.1.11)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "[notice] A new release of pip is available: 24.0 -> 24.3.1\n",
-      "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "!python -m pip install -U HypergraphAnalysisToolbox"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Load HIF File"
+    "import json\n",
+    "import os\n",
+    "\n",
+    "import fastjsonschema\n",
+    "from HAT import Hypergraph"
    ]
   },
   {
@@ -61,20 +41,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
-    "import sys\n",
-    "import json\n",
-    "import fastjsonschema\n",
-    "from HAT import Hypergraph"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "with open(os.path.join('data', 'e-coli.json'), 'r') as file:\n",
+    "with open(os.path.join(\"data\", \"e-coli.json\"), \"r\") as file:\n",
     "    # Load the JSON data from the file\n",
     "    hif_data = json.load(file)"
    ]
@@ -90,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -106,7 +73,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -212,7 +179,7 @@
        "[72 rows x 2 columns]"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -223,7 +190,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -366,7 +333,7 @@
        "[141 rows x 4 columns]"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -386,7 +353,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -395,17 +362,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
-    "schema = json.load(open('../schemas/hif_schema_v0.1.0.json','r'))\n",
+    "schema = json.load(open(\"../schemas/hif_schema_v0.1.0.json\", \"r\"))\n",
     "validator = fastjsonschema.compile(schema)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -422,14 +389,14 @@
     "## The validator confirms the json read conforms to the HIF standard\n",
     "output = validator(hif_output)\n",
     "\n",
-    "print('metadata: ',     output['metadata'],'\\n')\n",
-    "print('network-type: ', output['network-type'])"
+    "print(\"metadata: \", output[\"metadata\"], \"\\n\")\n",
+    "print(\"network-type: \", output[\"network-type\"])"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "xgi",
    "language": "python",
    "name": "python3"
   },
@@ -443,7 +410,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,

--- a/tutorials/HAT.ipynb
+++ b/tutorials/HAT.ipynb
@@ -1,0 +1,451 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Examples using HIF translators with HAT\n",
+    "\n",
+    "[HAT (Hypergraph Analysis Toolbox)](https://hypergraph-analysis-toolbox.readthedocs.io/en/latest/) is a python package for studying the structure and dynamics of hypergraphs. This notebook provides examples to make `HAT.Hypergraph`s compatible with other libraries based on the HIF standard.\n",
+    "\n",
+    "This notebook has three parts:\n",
+    "1. Install and import the packages\n",
+    "2. Load a HIF compatible JSON file\n",
+    "3. Build the `HAT.Hypergraph`\n",
+    "4. Demonstrate how to reproduce a HIF compatible hypergraph"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Install HAT"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: HypergraphAnalysisToolbox in c:\\users\\jpic\\appdata\\local\\programs\\python\\python311\\lib\\site-packages (1.1.11)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "[notice] A new release of pip is available: 24.0 -> 24.3.1\n",
+      "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
+     ]
+    }
+   ],
+   "source": [
+    "!python -m pip install -U HypergraphAnalysisToolbox"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load HIF File"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import sys\n",
+    "import json\n",
+    "import fastjsonschema\n",
+    "from HAT import Hypergraph"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(os.path.join('data', 'e-coli.json'), 'r') as file:\n",
+    "    # Load the JSON data from the file\n",
+    "    hif_data = json.load(file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Convert to HAT\n",
+    "\n",
+    "The `HAT.Hypergraph.from_hif` method converts the data loaded from a HIF `JSON` file into a Hypergraph."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "HG = Hypergraph.from_hif(hif_data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Metadata associated with each node can be viewed in the `nodes` and `edges` dataframes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Nodes</th>\n",
+       "      <th>name</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>3pg_c</td>\n",
+       "      <td>3-Phospho-D-glycerate</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>succ_e</td>\n",
+       "      <td>Succinate</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>etoh_e</td>\n",
+       "      <td>Ethanol</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>13dpg_c</td>\n",
+       "      <td>3-Phospho-D-glyceroyl phosphate</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>fdp_c</td>\n",
+       "      <td>D-Fructose 1,6-bisphosphate</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>67</th>\n",
+       "      <td>6pgl_c</td>\n",
+       "      <td>6-phospho-D-glucono-1,5-lactone</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>68</th>\n",
+       "      <td>acon_C_c</td>\n",
+       "      <td>Cis-Aconitate</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>69</th>\n",
+       "      <td>h_e</td>\n",
+       "      <td>H+</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>70</th>\n",
+       "      <td>o2_c</td>\n",
+       "      <td>O2 O2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>71</th>\n",
+       "      <td>g3p_c</td>\n",
+       "      <td>Glyceraldehyde 3-phosphate</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>72 rows × 2 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       Nodes                             name\n",
+       "0      3pg_c            3-Phospho-D-glycerate\n",
+       "1     succ_e                        Succinate\n",
+       "2     etoh_e                          Ethanol\n",
+       "3    13dpg_c  3-Phospho-D-glyceroyl phosphate\n",
+       "4      fdp_c      D-Fructose 1,6-bisphosphate\n",
+       "..       ...                              ...\n",
+       "67    6pgl_c  6-phospho-D-glucono-1,5-lactone\n",
+       "68  acon_C_c                    Cis-Aconitate\n",
+       "69       h_e                               H+\n",
+       "70      o2_c                            O2 O2\n",
+       "71     g3p_c       Glyceraldehyde 3-phosphate\n",
+       "\n",
+       "[72 rows x 2 columns]"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "HG.nodes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>edge</th>\n",
+       "      <th>name</th>\n",
+       "      <th>Nodes</th>\n",
+       "      <th>Edges</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>SUCOAS_reverse</td>\n",
+       "      <td>Succinyl-CoA synthetase (ADP-forming)</td>\n",
+       "      <td>[19, 51, 32, 40, 36, 12]</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>EX_h2o_e</td>\n",
+       "      <td>H2O exchange</td>\n",
+       "      <td>[55]</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>MALt2_2</td>\n",
+       "      <td>Malate transport via proton symport (2 H)</td>\n",
+       "      <td>[57, 69, 41, 43]</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>FUM</td>\n",
+       "      <td>Fumarase</td>\n",
+       "      <td>[38, 17, 41]</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>H2Ot</td>\n",
+       "      <td>H2O transport via diffusion</td>\n",
+       "      <td>[55, 38]</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>136</th>\n",
+       "      <td>EX_mal__L_e</td>\n",
+       "      <td>L-Malate exchange</td>\n",
+       "      <td>[57]</td>\n",
+       "      <td>136</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>137</th>\n",
+       "      <td>PGK_reverse</td>\n",
+       "      <td>Phosphoglycerate kinase</td>\n",
+       "      <td>[19, 3, 0, 40]</td>\n",
+       "      <td>137</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>138</th>\n",
+       "      <td>PPC</td>\n",
+       "      <td>Phosphoenolpyruvate carboxylase</td>\n",
+       "      <td>[38, 64, 11, 9, 51, 43]</td>\n",
+       "      <td>138</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>139</th>\n",
+       "      <td>PTAr_reverse</td>\n",
+       "      <td>Phosphotransacetylase</td>\n",
+       "      <td>[36, 22, 23, 51]</td>\n",
+       "      <td>139</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>140</th>\n",
+       "      <td>PTAr</td>\n",
+       "      <td>Phosphotransacetylase</td>\n",
+       "      <td>[23, 51, 36, 22]</td>\n",
+       "      <td>140</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>141 rows × 4 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "               edge                                       name  \\\n",
+       "0    SUCOAS_reverse      Succinyl-CoA synthetase (ADP-forming)   \n",
+       "1          EX_h2o_e                               H2O exchange   \n",
+       "2           MALt2_2  Malate transport via proton symport (2 H)   \n",
+       "3               FUM                                   Fumarase   \n",
+       "4              H2Ot                H2O transport via diffusion   \n",
+       "..              ...                                        ...   \n",
+       "136     EX_mal__L_e                          L-Malate exchange   \n",
+       "137     PGK_reverse                    Phosphoglycerate kinase   \n",
+       "138             PPC            Phosphoenolpyruvate carboxylase   \n",
+       "139    PTAr_reverse                      Phosphotransacetylase   \n",
+       "140            PTAr                      Phosphotransacetylase   \n",
+       "\n",
+       "                        Nodes  Edges  \n",
+       "0    [19, 51, 32, 40, 36, 12]      0  \n",
+       "1                        [55]      1  \n",
+       "2            [57, 69, 41, 43]      2  \n",
+       "3                [38, 17, 41]      3  \n",
+       "4                    [55, 38]      4  \n",
+       "..                        ...    ...  \n",
+       "136                      [57]    136  \n",
+       "137            [19, 3, 0, 40]    137  \n",
+       "138   [38, 64, 11, 9, 51, 43]    138  \n",
+       "139          [36, 22, 23, 51]    139  \n",
+       "140          [23, 51, 36, 22]    140  \n",
+       "\n",
+       "[141 rows x 4 columns]"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "HG.edges"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Convert Back to HIF\n",
+    "\n",
+    "The `Hypergraph.to_hif` method converts the hypergraph object back to a python dictionary according to the HIF schema. This dictionary can be saved to a `JSON` file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hif_output = HG.to_hif()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "schema = json.load(open('../schemas/hif_schema_v0.1.0.json','r'))\n",
+    "validator = fastjsonschema.compile(schema)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "metadata:  {'uniform': False, 'order': -1, 'directed': False} \n",
+      "\n",
+      "network-type:  undirected\n"
+     ]
+    }
+   ],
+   "source": [
+    "## The validator confirms the json read conforms to the HIF standard\n",
+    "output = validator(hif_output)\n",
+    "\n",
+    "print('metadata: ',     output['metadata'],'\\n')\n",
+    "print('network-type: ', output['network-type'])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tutorials/hnx.ipynb
+++ b/tutorials/hnx.ipynb
@@ -23,14 +23,14 @@
    },
    "outputs": [],
    "source": [
-    "import pandas as pd\n",
-    "import numpy as np\n",
     "import json\n",
-    "import warnings\n",
     "import random\n",
-    "import matplotlib.pyplot as plt\n",
+    "import warnings\n",
     "\n",
-    "import fastjsonschema"
+    "import fastjsonschema\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import pandas as pd"
    ]
   },
   {
@@ -47,7 +47,7 @@
    },
    "outputs": [],
    "source": [
-    "warnings.simplefilter('ignore')"
+    "warnings.simplefilter(\"ignore\")"
    ]
   },
   {
@@ -73,7 +73,7 @@
    },
    "outputs": [],
    "source": [
-    "schema = json.load(open('../schemas/hif_schema_v0.1.0.json','r'))\n",
+    "schema = json.load(open(\"../schemas/hif_schema_v0.1.0.json\", \"r\"))\n",
     "validator = fastjsonschema.compile(schema)"
    ]
   },
@@ -408,7 +408,7 @@
     }
    ],
    "source": [
-    "hnx.info_dict(lm)\n"
+    "hnx.info_dict(lm)"
    ]
   },
   {
@@ -436,9 +436,11 @@
     }
    ],
    "source": [
-    "edges = lm.restrict_to_nodes(['FN']).edges.items\n",
-    "lm_small = lm.restrict_to_edges(edges).collapse_nodes_and_edges(use_node_uids=['FN','JV'],use_counts=True,return_counts=True)\n",
-    "plt.title('Subhypergraph of LesMis')\n",
+    "edges = lm.restrict_to_nodes([\"FN\"]).edges.items\n",
+    "lm_small = lm.restrict_to_edges(edges).collapse_nodes_and_edges(\n",
+    "    use_node_uids=[\"FN\", \"JV\"], use_counts=True, return_counts=True\n",
+    ")\n",
+    "plt.title(\"Subhypergraph of LesMis\")\n",
     "plt.gcf().set_figheight(5)\n",
     "hnx.draw(lm_small)"
    ]
@@ -468,14 +470,13 @@
    ],
    "source": [
     "### View what is saved in HIF and save json to data\n",
-    "lesmis_hif = hnx.to_hif(lm, filename=\"data/lesmis.hif.json\") \n",
+    "lesmis_hif = hnx.to_hif(lm, filename=\"data/lesmis.hif.json\")\n",
     "\n",
     "## The validator confirms the json read conforms to the HIF standard\n",
     "output = validator(lesmis_hif)\n",
     "\n",
-    "print('metadata: ',output['metadata'],'\\n')\n",
-    "print('network-type: ',output['network-type'])\n",
-    "    "
+    "print(\"metadata: \", output[\"metadata\"], \"\\n\")\n",
+    "print(\"network-type: \", output[\"network-type\"])"
    ]
   },
   {
@@ -508,7 +509,7 @@
    ],
    "source": [
     "## Retrieve the hypergraph from HIF\n",
-    "h = hnx.from_hif(filename='data/lesmis.hif.json')\n",
+    "h = hnx.from_hif(filename=\"data/lesmis.hif.json\")\n",
     "hnx.info_dict(h)"
    ]
   },
@@ -679,7 +680,7 @@
     }
    ],
    "source": [
-    "chs = json.load(open('data/contacts-high-school-not-hif.json','r'))\n",
+    "chs = json.load(open(\"data/contacts-high-school-not-hif.json\", \"r\"))\n",
     "chs.keys()"
    ]
   },
@@ -893,8 +894,8 @@
    ],
    "source": [
     "### Create a nodes dataframe with all of the properties\n",
-    "chsnodes = pd.DataFrame(chs['nodes'])\n",
-    "chsnodes = chsnodes.set_index('id').reset_index()\n",
+    "chsnodes = pd.DataFrame(chs[\"nodes\"])\n",
+    "chsnodes = chsnodes.set_index(\"id\").reset_index()\n",
     "chsnodes"
    ]
   },
@@ -913,9 +914,18 @@
    "outputs": [],
    "source": [
     "## Create an incidences datafame with timestamps included\n",
-    "chsinc = pd.DataFrame(chs['hyperedges']).reset_index().rename(columns={\"index\":\"edge\",\"interaction\":\"node\"})\n",
-    "df = chsinc['node'].explode().reset_index().rename(columns={\"index\":\"edge\",'interaction':\"node\"})\n",
-    "df['time'] = [chsinc.loc[row.edge].time for row in df.itertuples()]"
+    "chsinc = (\n",
+    "    pd.DataFrame(chs[\"hyperedges\"])\n",
+    "    .reset_index()\n",
+    "    .rename(columns={\"index\": \"edge\", \"interaction\": \"node\"})\n",
+    ")\n",
+    "df = (\n",
+    "    chsinc[\"node\"]\n",
+    "    .explode()\n",
+    "    .reset_index()\n",
+    "    .rename(columns={\"index\": \"edge\", \"interaction\": \"node\"})\n",
+    ")\n",
+    "df[\"time\"] = [chsinc.loc[row.edge].time for row in df.itertuples()]"
    ]
   },
   {
@@ -1060,7 +1070,9 @@
    },
    "outputs": [],
    "source": [
-    "chshyp = hnx.Hypergraph(df,node_properties=chsnodes,name='contacts-high-school from XGI')"
+    "chshyp = hnx.Hypergraph(\n",
+    "    df, node_properties=chsnodes, name=\"contacts-high-school from XGI\"\n",
+    ")"
    ]
   },
   {
@@ -1102,8 +1114,8 @@
     "# CPU times: user 27.7 s, sys: 259 ms, total: 27.9 s\n",
     "# Wall time: 28 s\n",
     "\n",
-    "hif = hnx.to_hif(chshyp,filename='../tutorials/data/contacts_high_school.hif.json')\n",
-    "hif['metadata']"
+    "hif = hnx.to_hif(chshyp, filename=\"../tutorials/data/contacts_high_school.hif.json\")\n",
+    "hif[\"metadata\"]"
    ]
   },
   {
@@ -1290,7 +1302,7 @@
     "# CPU times: user 1e+03 ns, sys: 1e+03 ns, total: 2 μs\n",
     "# Wall time: 2.86 μs\n",
     "\n",
-    "H = hnx.from_hif(filename='../tutorials/data/contacts_high_school.hif.json')\n",
+    "H = hnx.from_hif(filename=\"../tutorials/data/contacts_high_school.hif.json\")\n",
     "H.nodes.dataframe.head()"
    ]
   },
@@ -1393,7 +1405,7 @@
    ],
    "source": [
     "imp.reload(hnx)\n",
-    "H = hnx.from_hif(filename='../tutorials/data/e-coli.json')\n",
+    "H = hnx.from_hif(filename=\"../tutorials/data/e-coli.json\")\n",
     "H.edges.dataframe.head()"
    ]
   },
@@ -1457,7 +1469,7 @@
     }
    ],
    "source": [
-    "H = hnx.from_hif(filename='../tutorials/data/email-enron.json')\n",
+    "H = hnx.from_hif(filename=\"../tutorials/data/email-enron.json\")\n",
     "H.name"
    ]
   },
@@ -1671,7 +1683,7 @@
     }
    ],
    "source": [
-    "plt.hist(hnx.edge_size_dist(H),log=True)"
+    "plt.hist(hnx.edge_size_dist(H), log=True)"
    ]
   },
   {

--- a/tutorials/integration.ipynb
+++ b/tutorials/integration.ipynb
@@ -6,12 +6,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import xgi\n",
-    "import nx_hif\n",
-    "import hypernetx as hnx\n",
     "import hypergraphx as hgx\n",
+    "import hypernetx as hnx\n",
     "import networkx as nx\n",
-    "import numpy as np"
+    "import numpy as np\n",
+    "import nx_hif\n",
+    "import xgi"
    ]
   },
   {

--- a/tutorials/nx.ipynb
+++ b/tutorials/nx.ipynb
@@ -6,8 +6,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import networkx as nx\n",
-    "import json"
+    "import json\n",
+    "\n",
+    "import networkx as nx"
    ]
   },
   {
@@ -28,9 +29,11 @@
     "    G.add_node(node, bipartite=0)\n",
     "    G.add_edge(edge, node)\n",
     "\n",
+    "\n",
     "def add_attrs(G: nx.DiGraph, edge_or_node, attrs):\n",
     "    for attr_key, attr_value in attrs.items():\n",
     "        G.nodes[edge_or_node][attr_key] = attr_value\n",
+    "\n",
     "\n",
     "def read_hif(path):\n",
     "    with open(path) as file:\n",
@@ -45,6 +48,8 @@
     "        attrs = record[\"attr\"]\n",
     "        add_attrs(G, n, attrs)\n",
     "    return G\n",
+    "\n",
+    "\n",
     "G_hif = read_hif(\"data/email-enron.json\")"
    ]
   },
@@ -65,7 +70,9 @@
     }
    ],
    "source": [
-    "pos = nx.bipartite_layout(G_hif, {n for n, d in G_hif.nodes(data=True) if d[\"bipartite\"] == 0})\n",
+    "pos = nx.bipartite_layout(\n",
+    "    G_hif, {n for n, d in G_hif.nodes(data=True) if d[\"bipartite\"] == 0}\n",
+    ")\n",
     "nx.draw(G_hif, pos=pos)"
    ]
   },
@@ -229,10 +236,7 @@
    ],
    "source": [
     "# get all the email addresses for every node\n",
-    "{\n",
-    "    n: d[\"name\"]\n",
-    "    for n, d in G_hif.nodes(data=True)\n",
-    "    if d[\"bipartite\"] == 0 }"
+    "{n: d[\"name\"] for n, d in G_hif.nodes(data=True) if d[\"bipartite\"] == 0}"
    ]
   }
  ],


### PR DESCRIPTION
This PR adds a jupyter notebook tutorial for reading and writing Hypergraphs from [Hypergraph Analysis Toolbox (HAT)](https://hypergraph-analysis-toolbox.readthedocs.io/en/latest/) to the HIF standard. This notebook is created at the request of @colltoaction in https://github.com/Jpickard1/Hypergraph-Analysis-Toolbox/issues/39

The notebook follows a similar format to the tutorial for `hypernetx` here: https://github.com/pszufe/HIF-standard/blob/main/tutorials/hnx.ipynb
1. Install HAT
2. Load HIF file
3. Convert HIF to `HAT.Hypergraph`
4. Convert `HAT.Hypergraph` to a new HIF file

**Note about HAT:**  
We are actively working on the release of v2 of HAT and updating it regularly. Methods to ensure compatibility with HIF are available starting from [`v1.1.11`](https://pypi.org/project/HypergraphAnalysisToolbox/).  

Please let me know if additional changes are needed!
